### PR TITLE
Remove versioneye badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![Latest Release](https://jitpack.io/v/atomfrede/jadenticon.svg?style=flat-square)](https://jitpack.io/#atomfrede/jadenticon)
 [![Codacy](https://img.shields.io/codacy/763a55e6006647a1ab02d50ffb870869.svg?style=flat-square)](https://www.codacy.com/app/frederik-hahne/jadenticon/dashboard)
 [![Codecov branch](https://img.shields.io/codecov/c/github/atomfrede/jadenticon/master.svg?style=flat-square)](https://codecov.io/github/atomfrede/jadenticon?branch=master)
-[![Dependency Status](https://www.versioneye.com/user/projects/56ce019e6b21e5003abcd54c/badge.svg?style=flat)](https://www.versioneye.com/user/projects/56ce019e6b21e5003abcd54c)
 [![Gitter](https://img.shields.io/gitter/room/atomfrede/jadenticon.js.svg?style=flat-square)](https://gitter.im/atomfrede/jadenticon)
 
 # Jadenticon


### PR DESCRIPTION
As versioneye will be closed in dec. 17 already removing the badge :(